### PR TITLE
Fix clpctl update not updating the system

### DIFF
--- a/src/CLP.CLI/Commands/UpdateCommand.cs
+++ b/src/CLP.CLI/Commands/UpdateCommand.cs
@@ -62,7 +62,14 @@ public class UpdateCommand
 
                             // Ensure the patch has not been compromised
                             ChecksumUtility.ComputeChecksum(patchPath);
-;
+
+                            // Prepare the folder to /opt/CLP for extraction
+                            // Should be handled by ClpPackager, .NET somethimes can be weird
+                            if (!Directory.Exists($"/opt/CLP/{patchName}"))
+                            {
+                                Directory.CreateDirectory($"/opt/CLP/{patchName}");
+                            }
+
                             // Call the packager to apply the patches
                             var packager = new ClpPackager();
                             packager.ExtractClpFile(patchPath, $"/opt/CLP/{patchName}");

--- a/src/CLP.CLI/Commands/UpdateCommand.cs
+++ b/src/CLP.CLI/Commands/UpdateCommand.cs
@@ -1,5 +1,5 @@
+using CLP.Core;
 using CLP.Packager;
-using CLP.SystemIntegration;
 using System;
 using System.CommandLine;
 using System.Diagnostics;
@@ -59,16 +59,21 @@ public class UpdateCommand
                         {
                             var patchData = await patchResponse.Content.ReadAsByteArrayAsync();
                             File.WriteAllBytes(patchPath, patchData);
+
+                            // Ensure the patch has not been compromised
+                            ChecksumUtility.ComputeChecksum(patchPath);
+;
+                            // Call the packager to apply the patches
+                            var packager = new ClpPackager();
+                            packager.ExtractClpFile(patchPath, $"/opt/CLP/{patchName}");
                             Console.WriteLine($"Downloaded patch: {patchName}");
                         }
                         else
                         {
                             Console.Error.WriteLine($"Failed to download patch: {patchName}");
                         }
-                        // Call the packager to apply the patches
-                        var packager = new ClpPackager();
-                        packager.ExtractClpFile(patchPath, $"/opt/CLP/{patchName}");
                     }
+                    continue;
                 }
 
                 // Execute the installation scripts for each patch

--- a/src/CLP.Packager/ClpPackager.cs
+++ b/src/CLP.Packager/ClpPackager.cs
@@ -66,9 +66,9 @@ public class ClpPackager
             }
         };
 
+        process.Start();
         string stdout = process.StandardOutput.ReadToEnd();
         string stderr = process.StandardError.ReadToEnd();
-        process.Start();
         process.WaitForExit();
     }
 }


### PR DESCRIPTION
This Pull request address the following issue #3 when you cannot update the system due to an error from the `clpctl update` command line.

The ``CLP.Packager`` has been fixed to create a folder if the directory output doesn't exist and the Update command from ``CLP.CLI`` has been reviewed to execute patches after downloading.